### PR TITLE
improvements for initial data drop

### DIFF
--- a/src/nxslib/comm.py
+++ b/src/nxslib/comm.py
@@ -76,7 +76,9 @@ class CommHandler:
 
     def _drop_all(self) -> None:
         """Drop all frames."""
+        # drop frames from interface
         self._intf.drop_all()
+        # drop cached frames
         self._drop_all_frames()
 
     def _recv_thread(self) -> None:
@@ -272,14 +274,14 @@ class CommHandler:
             # start interface
             self._intf.start()
 
-            # start recv thread
-            self._thrd.thread_start()
-
             # send stop request
             self.stream_stop()
 
             # drop all pending data
             self._drop_all()
+
+            # start recv thread
+            self._thrd.thread_start()
 
             # get info frame
             timeout = 5

--- a/src/nxslib/intf/rtt.py
+++ b/src/nxslib/intf/rtt.py
@@ -94,8 +94,11 @@ class RTTDevice(ICommInterface):  # pragma: no cover
 
     def drop_all(self) -> None:
         """Drop all frames."""
-        for _ in range(10):
-            self._read()
+        cntr = 4
+        while cntr > 0:
+            ret = self._read()
+            if not ret:  # pragma: no cover
+                cntr -= 1
 
     def _read(self) -> bytes:
         """Interface specific read method."""

--- a/src/nxslib/intf/serial.py
+++ b/src/nxslib/intf/serial.py
@@ -61,8 +61,11 @@ class SerialDevice(ICommInterface):
 
     def drop_all(self) -> None:
         """Drop all frames."""
-        for _ in range(10):
-            self._read()
+        cntr = 4
+        while cntr > 0:
+            ret = self._read()
+            if not ret:  # pragma: no cover
+                cntr -= 1
 
     def _read(self) -> bytes:
         """Interface specific read method."""


### PR DESCRIPTION
- comm.py: start recv thread after dropping spurious data
- intf: improve drop_all logic

this fix various parser errors that sometime happens when there are spurious data on communication interface (eg previous nxscli session was interrupted without stopping nxscope stream)

